### PR TITLE
feat(tui): improve app api

### DIFF
--- a/sonas/src/sonas/component.rs
+++ b/sonas/src/sonas/component.rs
@@ -7,12 +7,12 @@ mod navbar_button;
 mod root;
 mod scrollable;
 
+pub use logger::LoggerComponent;
 pub use root::RootComponent;
 
 use album_card::AlbumCardComponent;
 use control_panel::ControlPanelComponent;
 use library::LibraryComponent;
-use logger::LoggerComponent;
 use navbar::NavbarComponent;
 use navbar_button::NavbarButtonComponent;
 use scrollable::ScrollableComponent;

--- a/sonas/src/sonas/main.rs
+++ b/sonas/src/sonas/main.rs
@@ -20,6 +20,6 @@ async fn main() -> eyre::Result<()> {
 	let cli = Cli::new();
 	let app = App::<AppEvent>::new()
 		.with_component(ConfigManager::<AppEvent>::new(cli.config_path()))?
-		.with_main_component(RootComponent::default())?;
+		.with_component(RootComponent::default())?;
 	app.run().await
 }

--- a/sonas/src/sonas/main.rs
+++ b/sonas/src/sonas/main.rs
@@ -9,7 +9,7 @@ use color_eyre::eyre;
 
 use app_event::AppEvent;
 use cli::Cli;
-use component::RootComponent;
+use component::{LoggerComponent, RootComponent};
 use config::ConfigManager;
 
 use crate::tui::app::App;
@@ -18,8 +18,12 @@ use crate::tui::app::App;
 async fn main() -> eyre::Result<()> {
 	color_eyre::install()?;
 	let cli = Cli::new();
-	let app = App::<AppEvent>::new()
-		.with_component(ConfigManager::<AppEvent>::new(cli.config_path()))?
-		.with_component(RootComponent::default())?;
-	app.run().await
+	App::<AppEvent>::new()
+		.with_entity(|e| {
+			e.with_component(LoggerComponent::new())?
+				.with_component(ConfigManager::<AppEvent>::new(cli.config_path()))?
+				.with_component(RootComponent::default())
+		})?
+		.run()
+		.await
 }

--- a/sonas/src/sonas/tui/app.rs
+++ b/sonas/src/sonas/tui/app.rs
@@ -74,14 +74,6 @@ where
 		Ok(self)
 	}
 
-	/// Adds a new component to the bevy ecs and focusses it
-	pub fn with_main_component(mut self, component_bundle: impl Bundle) -> eyre::Result<Self> {
-		let entity = self.ecs.add_component(component_bundle);
-		self.ecs.set_focus(entity);
-		self.ecs.init()?;
-		Ok(self)
-	}
-
 	/// Runs the `App` until completion
 	pub async fn run(mut self) -> eyre::Result<()> {
 		let mut tui = Terminal::new()?;

--- a/sonas/src/sonas/tui/app.rs
+++ b/sonas/src/sonas/tui/app.rs
@@ -1,6 +1,9 @@
+mod entity_builder;
+
+pub use entity_builder::EntityBuilder;
+
 use std::io;
 
-use bevy_ecs::bundle::Bundle;
 use color_eyre::eyre;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -67,11 +70,11 @@ where
 		}
 	}
 
-	/// Adds a new component to the bevy ecs
-	pub fn with_component(mut self, component_bundle: impl Bundle) -> eyre::Result<Self> {
-		self.ecs.add_component(component_bundle);
-		self.ecs.init()?;
-		Ok(self)
+	pub fn with_entity(
+		mut self,
+		f: impl FnOnce(EntityBuilder<T>) -> eyre::Result<EntityBuilder<T>>,
+	) -> eyre::Result<Self> {
+		Ok((f)(EntityBuilder::new(self.ecs.add_entity(), self))?.app())
 	}
 
 	/// Runs the `App` until completion

--- a/sonas/src/sonas/tui/app/entity_builder.rs
+++ b/sonas/src/sonas/tui/app/entity_builder.rs
@@ -1,0 +1,43 @@
+use bevy_ecs::{component::Component, entity::Entity};
+use color_eyre::eyre;
+
+use super::App;
+
+#[derive(Debug)]
+pub struct EntityBuilder<T>
+where
+	T: 'static,
+{
+	entity: Entity,
+	app: App<T>,
+}
+
+#[allow(dead_code)]
+impl<T> EntityBuilder<T>
+where
+	T: Send + Sync + 'static,
+{
+	pub fn new(entity: Entity, app: App<T>) -> Self {
+		Self { entity, app }
+	}
+
+	pub fn id(&self) -> Entity {
+		self.entity
+	}
+
+	pub fn app(self) -> App<T> {
+		self.app
+	}
+
+	pub fn with_child(mut self, f: impl FnOnce(Self) -> eyre::Result<Self>) -> eyre::Result<Self> {
+		let entity = self.entity;
+		let app = (f)(EntityBuilder::new(self.app.ecs.add_entity(), self.app))?.app;
+		Ok(Self::new(entity, app))
+	}
+
+	pub fn with_component(mut self, component_bundle: impl Component) -> eyre::Result<Self> {
+		self.app.ecs.add_component(self.entity, component_bundle);
+		self.app.ecs.init()?;
+		Ok(self)
+	}
+}

--- a/sonas/src/sonas/tui/ecs.rs
+++ b/sonas/src/sonas/tui/ecs.rs
@@ -56,10 +56,6 @@ where
 		self.world.spawn(component_bundle).id()
 	}
 
-	pub fn set_focus(&mut self, target: Entity) {
-		self.world.resource_mut::<Focus>().target = target;
-	}
-
 	pub fn init(&mut self) -> eyre::Result<()> {
 		self.world.flush();
 		self.world.run_system_cached(init_components)?;

--- a/sonas/src/sonas/tui/ecs.rs
+++ b/sonas/src/sonas/tui/ecs.rs
@@ -52,8 +52,12 @@ where
 		}
 	}
 
-	pub fn add_component(&mut self, component_bundle: impl Bundle) -> Entity {
-		self.world.spawn(component_bundle).id()
+	pub fn add_entity(&mut self) -> Entity {
+		self.world.spawn_empty().id()
+	}
+
+	pub fn add_component(&mut self, entity: Entity, component_bundle: impl Bundle) {
+		self.world.entity_mut(entity).insert(component_bundle);
 	}
 
 	pub fn init(&mut self) -> eyre::Result<()> {


### PR DESCRIPTION
This change to the app builder API allows creating nested entity structures with any amount of components on each, without the use of the init system. The improvement this gives over just initialising the tree using init systems is that you now have complete control over the order in which the init systems are triggered, even for components on the same entity.